### PR TITLE
Add a "transliterate" option to multisearchable to remove accents

### DIFF
--- a/lib/pg_search.rb
+++ b/lib/pg_search.rb
@@ -11,6 +11,7 @@ require "pg_search/multisearch"
 require "pg_search/multisearchable"
 require "pg_search/normalizer"
 require "pg_search/scope_options"
+require "pg_search/transliterator"
 require "pg_search/version"
 
 module PgSearch

--- a/lib/pg_search/configuration.rb
+++ b/lib/pg_search/configuration.rb
@@ -76,6 +76,10 @@ module PgSearch
       model.connection.send(:postgresql_version)
     end
 
+    def transliterate
+      options[:transliterate]
+    end
+
     private
 
     attr_reader :options
@@ -85,7 +89,7 @@ module PgSearch
     end
 
     VALID_KEYS = %w[
-      against ranked_by ignoring using query associated_against order_within_rank
+      against ranked_by ignoring using query associated_against order_within_rank transliterate
     ].map(&:to_sym)
 
     VALID_VALUES = {

--- a/lib/pg_search/document.rb
+++ b/lib/pg_search/document.rb
@@ -31,7 +31,15 @@ module PgSearch
     def update_content
       methods = Array(searchable.pg_search_multisearchable_options[:against])
       searchable_text = methods.map { |symbol| searchable.send(symbol) }.join(" ")
-      self.content = searchable_text
+      self.content = searchable_text_to_content(searchable_text)
+    end
+
+    def searchable_text_to_content(searchable_text)
+      if PgSearch.multisearch_options.is_a?(Hash) && PgSearch.multisearch_options[:transliterate]
+        Transliterator.transliterate(searchable_text)
+      else
+        searchable_text
+      end
     end
   end
 end

--- a/lib/pg_search/scope_options.rb
+++ b/lib/pg_search/scope_options.rb
@@ -73,7 +73,7 @@ module PgSearch
       normalizer = Normalizer.new(config)
 
       feature_class.new(
-        config.query,
+        query,
         feature_options[feature_name],
         config.columns,
         config.model,
@@ -84,6 +84,14 @@ module PgSearch
     def rank
       (config.ranking_sql || ":tsearch").gsub(/:(\w*)/) do
         feature_for($1).rank.to_sql
+      end
+    end
+
+    def query
+      if config.transliterate
+        Transliterator.transliterate(config.query)
+      else
+        config.query
       end
     end
   end

--- a/lib/pg_search/transliterator.rb
+++ b/lib/pg_search/transliterator.rb
@@ -1,0 +1,9 @@
+require 'active_support/inflector'
+
+module PgSearch
+  class Transliterator
+    def self.transliterate(content)
+      ActiveSupport::Inflector.transliterate(content)
+    end
+  end
+end


### PR DESCRIPTION
Add a "transliterate" option to multisearchable to remove accents from characters before saving the data and when using PgSearch.multisearch.

This can be used as alternative for ignoring: :accents and has the benefit that multisearch can take advantage of an index.